### PR TITLE
Link with lts_array docs

### DIFF
--- a/array_processing/tools/plotting.py
+++ b/array_processing/tools/plotting.py
@@ -22,8 +22,9 @@ def array_plot(st, t, mdccm, vel, baz, ccmplot=False,
             subplot.
         sigma_tau: Array of :math:`\sigma_\tau` values. If provided, will plot
             the values on a separate subplot.
-        stdict (dict): Dropped station pairs from LTS processing. If provided, will plot
-            the dropped station pairs on a separate subplot.
+        stdict (dict): Dropped station pairs from
+            :func:`~lts_array.ltsva.ltsva`. If provided, will plot the dropped
+            station pairs on a separate subplot.
 
     Returns:
         tuple: Tuple containing:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -42,5 +42,5 @@ intersphinx_mapping = {
     'numpy': ('https://docs.scipy.org/doc/numpy', None),
     'obspy': ('https://docs.obspy.org/', None),
     'matplotlib': ('https://matplotlib.org/', None),
-    'waveform_collection': ('https://uaf-waveform-collection.readthedocs.io/en/master/', None),
+    'lts_array': ('https://uaf-lts-array.readthedocs.io/en/latest/', None)
 }


### PR DESCRIPTION
Use [`sphinx.ext.intersphinx`](https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html). @jwbishop let me know if there are any other places where we could link! This is the only relevant place I found.