### PR TITLE
Add KML parsing function

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ development.
 For installation into a pre-existing conda environment, click here.
 </summary>
 <br>
-First ensure you have ObsPy installed (<code>conda install -c conda-forge
-obspy</code>) and then download and install the <em>uafgeotools</em>
+First ensure you have ObsPy and FastKML installed (<code>conda install -c conda-forge
+obspy fastkml</code>) and then download and install the <em>uafgeotools</em>
 dependencies and this package with:
 <br>
 <br>
@@ -84,7 +84,8 @@ _uafgeotools_ packages:
 
 Python packages:
 
-* [ObsPy](http://docs.obspy.org/)
+* [ObsPy](https://docs.obspy.org/)
+* [FastKML](https://fastkml.readthedocs.io/)
 
 Usage
 -----

--- a/array_processing/tools/__init__.py
+++ b/array_processing/tools/__init__.py
@@ -1,6 +1,6 @@
 from .array_characterization import (arraySig, impulseResp, rthEllipse,
                                      co_array, chi2, cubicEqn, quadraticEqn,
-                                     quarticEqn)
+                                     quarticEqn, read_kml)
 from .detection import fstatbland
 from .generic import (array_thresh, beamForm, phaseAlignData, phaseAlignIdx,
                       tauCalcPW, tauCalcSW, tauCalcSWxy, randc, psf)

--- a/array_processing/tools/array_characterization.py
+++ b/array_processing/tools/array_characterization.py
@@ -1,6 +1,7 @@
 import numpy as np
 from scipy import optimize
 from scipy.special import gammainc
+from fastkml import kml
 
 
 def arraySig(rij, kmax, sigLevel, p=0.9, velLims=(0.27, 0.36), NgridV=100,
@@ -468,3 +469,28 @@ def quarticEqn(a, b, c, d):
                 x[k] = int(x[k])
 
     return x
+
+
+def read_kml(kml_file):
+    r"""Parse an array KML file into a list of element latitudes and longitudes.
+
+    KML file must contain a single folder containing the array element points.
+
+    Args:
+        kml_file (str): Full path to input KML file (extension ``.kml``)
+
+    Returns:
+        tuple: ``(latlist, lonlist)`` for input to :func:`~array_processing.algorithms.helpers.getrij`
+    """
+
+    # Read in KML file
+    k = kml.KML()
+    with open(kml_file, mode='rb') as f:
+        k.from_string(f.read())
+
+    # Extract coordinates
+    elements = list(list(list(k.features())[0].features())[0].features())
+    lonlist = [element.geometry.x for element in elements]
+    latlist = [element.geometry.y for element in elements]
+
+    return latlist, lonlist

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - fastkml
   - ipython
   - obspy
   - pip


### PR DESCRIPTION
This PR adds a small convenience function, `read_kml()`, which parses KML files (from e.g. Google Earth) into `latlist, lonlist` for input to `getrij()`. This should assist the array design process — users can tweak element positions in Google Earth, save the KML file, and then immediately assess e.g. the array response.

Example usage:
```python
rij = getrij(*read_kml('/path/to/TEST.kml'))
```
where `TEST.kml` has the structure:

<img width="121" alt="Screen Shot 2021-01-13 at 2 48 22 PM" src="https://user-images.githubusercontent.com/38269494/104526289-7de8a080-55ae-11eb-8278-b07b90debf56.png">
