### PR TITLE
Fix `read_kml()` by pinning fastkml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - python<3.11  # Temporary fix (see https://github.com/numba/numba/issues/8304)
-  - fastkml
+  - fastkml<1
   - ipython
   - obspy
   - numba


### PR DESCRIPTION
fastkml v1 and higher made a change that broke our code. This PR pins fastkml less than v1 which fixes the issue. Closes #47.